### PR TITLE
fix: resolve four issues reported in #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 - Nothing yet.
 
+## 2.1.0 - 2026-04-28
+
+Diff baseline: `v2.0.0`
+
+### Breaking Changes
+
+- None identified.
+
+### Added
+
+- `imgUploadHeaders` option on `editorOptions` — pass a `Record<string, string>` of HTTP headers (e.g. `Authorization`) to include in every image upload request. Documented in README.
+
+### Fixed
+
+- Code block background is now a solid `bg-neutral-900` (light mode) / `bg-neutral-800` (dark mode) with `text-neutral-100`, replacing the previous semi-transparent `bg-foreground/50` that caused a blur effect and made text invisible in dark mode.
+- Drag handle dropdown actions (duplicate block, delete, copy to clipboard, reset formatting) now execute correctly. The `onAction` handler was previously only calling `console.log`.
+- Slash command `/` menu now appears above dialogs and modals. Positioning strategy switched from `absolute` to `fixed` and z-index raised to `9999`.
+
 ## 2.0.0 - 2026-04-03
 
 Diff baseline: `v1.6.5`

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ export function EditorWithSlots() {
   Controls whether the block drag handle is rendered. Default: `true`.
 - `extraExtensions`
   Appends custom Tiptap extensions after the built-in editor set.
+- `imgUploadUrl`
+  The URL of the server endpoint that receives image uploads.
+- `imgUploadResponseKey`
+  Locates the image URL in the server response. Accepts a top-level key, a dot-separated path, a path array, or a resolver function.
+- `imgUploadHeaders`
+  Custom HTTP headers sent with every image upload request (e.g. `Authorization`).
 
 ## Built-in Extensions
 
@@ -366,6 +372,33 @@ The editor sends a `POST` request with `multipart/form-data` and the file under 
     }}
   />
   ```
+
+### Sending custom headers
+
+Use `imgUploadHeaders` to attach custom HTTP headers to every upload request. This is the standard way to pass an authorization token or any other API header.
+
+```tsx
+<TiptopEditor
+  editorOptions={{
+    imgUploadUrl: '/api/upload',
+    imgUploadResponseKey: 'url',
+    imgUploadHeaders: {
+      Authorization: 'Bearer YOUR_TOKEN',
+    },
+  }}
+/>
+```
+
+Multiple headers are supported:
+
+```tsx
+imgUploadHeaders: {
+  Authorization: 'Bearer YOUR_TOKEN',
+  'X-Api-Key': 'YOUR_API_KEY',
+}
+```
+
+> **Note**: The editor sends `multipart/form-data`. Do **not** include a `Content-Type` header in `imgUploadHeaders` — the browser sets it automatically with the correct boundary string.
 
 Your server response must include the uploaded image URL at the location you describe with `imgUploadResponseKey`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiptop-editor",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Notion-like editor built with Tiptap v3 and HeroUI",
   "type": "module",
   "main": "./dist/tiptop-editor.umd.js",

--- a/src/components/editor/TiptopDragHandle.tsx
+++ b/src/components/editor/TiptopDragHandle.tsx
@@ -9,7 +9,7 @@ import { commandGroups } from '../../constants'
 import type { icons } from 'lucide-react'
 import DragHandleColorList from './DragHandleColorList'
 import TransformIntoIcon from './TransformIntoIcon'
-import { canShowColorTransform, canShowNodeTransform, hasAtLeastOneMark, isUploadingImage, nodeHasTextContent, removeAllFormatting, transformNodeToAlternative } from '../../helpers'
+import { canShowColorTransform, canShowNodeTransform, copyNodeTextContent, deleteNode, duplicateNode, hasAtLeastOneMark, isUploadingImage, nodeHasTextContent, removeAllFormatting, transformNodeToAlternative } from '../../helpers'
 
 const excludedCommands = ['imageUploader'];
 
@@ -114,7 +114,12 @@ const TiptopDragHandle = ({ editor, dragHandleSlot }: { editor: Editor, dragHand
               shouldCloseOnSelect={true}
               disabledKeys={dragHandleDisabledKeys}
               className='w-[225px]'
-              onAction={(key) => console.log(key)}
+              onAction={(key) => {
+                if (key === 'duplicate_node') duplicateNode(editor)
+                else if (key === 'delete') deleteNode(editor)
+                else if (key === 'copy_to_clipboard') copyNodeTextContent(editor)
+                else if (key === 'reset_formatting') removeAllFormatting(editor)
+              }}
             >
               <Dropdown.Section>
                 {canShowColorTransform(editor)

--- a/src/components/editor/TiptopEditor.tsx
+++ b/src/components/editor/TiptopEditor.tsx
@@ -27,6 +27,7 @@ const TiptopEditor = forwardRef<TiptopEditorHandle, TiptopEditorProps>(
     const {
       imgUploadUrl,
       imgUploadResponseKey,
+      imgUploadHeaders,
       disableDefaultContainer = false,
       showDragHandle = true,
       extraExtensions = [],
@@ -35,8 +36,8 @@ const TiptopEditor = forwardRef<TiptopEditorHandle, TiptopEditorProps>(
     } = editorOptions
 
     const builtInExtensions = useMemo(
-      () => createDefaultExtensions({ imgUploadUrl, imgUploadResponseKey }),
-      [imgUploadResponseKey, imgUploadUrl]
+      () => createDefaultExtensions({ imgUploadUrl, imgUploadResponseKey, imgUploadHeaders }),
+      [imgUploadResponseKey, imgUploadUrl, imgUploadHeaders]
     )
 
     const extensions = useMemo(() => [
@@ -59,10 +60,12 @@ const TiptopEditor = forwardRef<TiptopEditorHandle, TiptopEditorProps>(
       extraExtensionsKey,
       imgUploadUrl,
       imgUploadResponseKey,
+      imgUploadHeaders,
     ], [
       extraExtensionsKey,
       imgUploadResponseKey,
       imgUploadUrl,
+      imgUploadHeaders,
       optionsKey,
     ])
 

--- a/src/components/editor/createDefaultExtensions.ts
+++ b/src/components/editor/createDefaultExtensions.ts
@@ -20,11 +20,13 @@ import { ImageUploadResponseResolver } from '../../types'
 interface CreateDefaultExtensionsOptions {
   imgUploadUrl?: string
   imgUploadResponseKey?: ImageUploadResponseResolver
+  imgUploadHeaders?: Record<string, string>
 }
 
 export const createDefaultExtensions = ({
   imgUploadUrl,
   imgUploadResponseKey,
+  imgUploadHeaders,
 }: CreateDefaultExtensionsOptions): Extensions => [
   StarterKit.configure({
     bulletList: false,
@@ -71,6 +73,7 @@ export const createDefaultExtensions = ({
   ImageUploaderExtension.configure({
     imgUploadUrl,
     imgUploadResponseKey,
+    imgUploadHeaders,
   }),
   SlashCommand.configure({
     suggestion: SlashCommandSuggestion

--- a/src/extensions/image/ImageUploaderExtension.ts
+++ b/src/extensions/image/ImageUploaderExtension.ts
@@ -19,6 +19,7 @@ export const ImageUploaderExtension = Extension.create<ImageUploaderExtensionOpt
     return {
       imgUploadUrl: undefined,
       imgUploadResponseKey: undefined,
+      imgUploadHeaders: undefined,
       allowedMimeTypes: ['image/jpeg', 'image/png', 'image/jpg'],
       maxFileSize: 5 * 1024 * 1024, // 5MB in bytes
     }
@@ -63,7 +64,7 @@ export const ImageUploaderExtension = Extension.create<ImageUploaderExtensionOpt
 
     return {
       uploadImageFromFile: (editor: Editor, file: File, id: string, updateExisting?: boolean, pos?: number) => {
-        const { imgUploadUrl, imgUploadResponseKey, allowedMimeTypes, maxFileSize } = this.options
+        const { imgUploadUrl, imgUploadResponseKey, imgUploadHeaders, allowedMimeTypes, maxFileSize } = this.options
 
         if (!file) return
 
@@ -214,6 +215,7 @@ export const ImageUploaderExtension = Extension.create<ImageUploaderExtensionOpt
               url: imgUploadUrl,
               onProgress: handleProgress,
               signal: abortController.signal,
+              headers: imgUploadHeaders,
             })
 
             // Check if cancelled after upload completes

--- a/src/extensions/slashCommand/SlashCommandList.tsx
+++ b/src/extensions/slashCommand/SlashCommandList.tsx
@@ -63,7 +63,7 @@ const SlashCommandList = forwardRef<KeyDownRef, {
   return (
     <div
       aria-label="Command menu"
-      className='w-[200px] bg-background border shadow rounded-2xl flex flex-col gap-2 p-2.5 relative z-5'
+      className='w-[200px] bg-background border shadow rounded-2xl flex flex-col gap-2 p-2.5 relative z-[9999]'
     >
       {items.length > 0 ? (
         items.map((group, groupIndex) => (

--- a/src/extensions/slashCommand/SlashCommandSuggestion.ts
+++ b/src/extensions/slashCommand/SlashCommandSuggestion.ts
@@ -15,7 +15,7 @@ const updatePosition = (editor: Editor, element: HTMLElement) => {
 
   computePosition(virtualElement, element, {
     placement: 'bottom-start',
-    strategy: 'absolute',
+    strategy: 'fixed',
     middleware: [shift(), flip()],
   }).then(({ x, y, strategy }) => {
     element.style.width = 'max-content'
@@ -67,7 +67,7 @@ const SlashCommandSuggestion: SlashCommandSuggestionOptions = {
           editor: props.editor,
         });
 
-        (reactRenderer.element as HTMLElement).style.position = 'absolute';
+        (reactRenderer.element as HTMLElement).style.position = 'fixed';
 
         document.body.appendChild(reactRenderer.element)
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -403,7 +403,7 @@ export const unsetLink = (editor: Editor) => {
   }
 }
 
-export const uploadWithProgress = async ({ file, url, onProgress, signal }: { file: File, url: string, onProgress: (percent: number) => boolean | void, signal?: AbortSignal }): Promise<Record<string, unknown>> => {
+export const uploadWithProgress = async ({ file, url, onProgress, signal, headers }: { file: File, url: string, onProgress: (percent: number) => boolean | void, signal?: AbortSignal, headers?: Record<string, string> }): Promise<Record<string, unknown>> => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     
@@ -455,6 +455,13 @@ export const uploadWithProgress = async ({ file, url, onProgress, signal }: { fi
     formData.append('file', file)
 
     xhr.open('POST', url)
+
+    if (headers) {
+      Object.entries(headers).forEach(([key, value]) => {
+        xhr.setRequestHeader(key, value)
+      })
+    }
+
     xhr.send(formData)
   })
 }

--- a/src/index.css
+++ b/src/index.css
@@ -177,7 +177,7 @@
 
   /* CodeBlock and code styles */
   pre {
-    @apply whitespace-pre-wrap my-6 rounded border border-surface bg-neutral-900 p-3 text-neutral-100 caret-neutral-100;
+    @apply whitespace-pre-wrap my-6 rounded border border-surface bg-neutral-900 dark:bg-neutral-800 p-3 text-neutral-100 caret-neutral-100;
 
     code {
       @apply bg-transparent p-0 text-inherit rounded-none border-none;

--- a/src/index.css
+++ b/src/index.css
@@ -177,7 +177,7 @@
 
   /* CodeBlock and code styles */
   pre {
-    @apply whitespace-pre-wrap my-6 rounded border border-surface bg-foreground/50 dark:bg-default p-3 text-background caret-background;
+    @apply whitespace-pre-wrap my-6 rounded border border-surface bg-neutral-900 p-3 text-neutral-100 caret-neutral-100;
 
     code {
       @apply bg-transparent p-0 text-inherit rounded-none border-none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,12 @@ export type TiptopEditorOptions = Omit<Partial<UseEditorOptions & {
  */
   imgUploadResponseKey?: ImageUploadResponseResolver
   /**
+ * Custom HTTP headers to include in the image upload request.
+ * Useful for passing authorization tokens or other API headers.
+ * @default undefined
+ */
+  imgUploadHeaders?: Record<string, string>
+  /**
  * Disables the default Card wrapper and removes the editor's built-in padding.
  * Use this when you want to embed the editor inside your own layout container.
  * @default false
@@ -232,6 +238,7 @@ export interface ImageUploaderExtensionOptions {
   imgUploadResponseKey?: ImageUploadResponseResolver
   allowedMimeTypes?: string[]
   maxFileSize: number
+  imgUploadHeaders?: Record<string, string>
 }
 
 export interface ImageUploaderExtensionStorage {


### PR DESCRIPTION
- Code block: replace semi-transparent bg-foreground/50 with solid
  bg-neutral-900 / text-neutral-100 so syntax highlighting is readable
  in both light and dark mode without any blur effect.

- Drag handle actions: wire up the onAction handler that was only
  console.log(key); now calls duplicateNode, deleteNode,
  copyNodeTextContent and removeAllFormatting correctly.

- Slash command z-index: switch positioning strategy from absolute to
  fixed and raise z-index to 9999 so the menu appears above dialogs.

- Image upload headers: add imgUploadHeaders option threaded through
  TiptopEditorOptions → createDefaultExtensions →
  ImageUploaderExtension → uploadWithProgress (xhr.setRequestHeader).
  Document the new option in README with Authorization example.

https://claude.ai/code/session_01UYjYtfYPKYPwt4r44goSnr